### PR TITLE
Workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,7 +534,7 @@ dependencies = [
  "hmac 0.10.1",
  "percent-encoding",
  "rand 0.8.5",
- "sha2",
+ "sha2 0.9.9",
  "time",
  "version_check",
 ]
@@ -1585,9 +1585,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6e86fb9e7026527a0d46bc308b841d73170ef8f443e1807f6ef88526a816d4"
+checksum = "4257b4a04d91f7e9e6290be5d3da4804dd5784fafde3a497d73eb2b4a158c30a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1595,9 +1595,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96504449aa860c8dcde14f9fba5c58dc6658688ca1fe363589d6327b8662c603"
+checksum = "241cda393b0cdd65e62e07e12454f1f25d57017dcc514b1514cd3c4645e3a0a6"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1605,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "798e0220d1111ae63d66cb66a5dcb3fc2d986d520b98e49e1852bfdb11d7c5e7"
+checksum = "46b53634d8c8196302953c74d5352f33d0c512a9499bd2ce468fc9f4128fa27c"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1618,13 +1618,13 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984298b75898e30a843e278a9f2452c31e349a073a0ce6fd950a12a74464e065"
+checksum = "0ef4f1332a8d4678b41966bb4cc1d0676880e84183a1ecc3f4b69f03e99c7a51"
 dependencies = [
  "once_cell",
  "pest",
- "sha1 0.10.5",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -2312,6 +2312,17 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -3230,7 +3241,7 @@ version = "0.7.0-rc"
 dependencies = [
  "async-std",
  "async-trait",
- "base64 0.20.0",
+ "base64 0.21.0",
  "env_logger",
  "git-version",
  "humantime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3181,7 +3181,7 @@ checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 [[package]]
 name = "zenoh"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-global-executor",
  "async-std",
@@ -3251,7 +3251,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "zenoh-collections",
 ]
@@ -3259,7 +3259,7 @@ dependencies = [
 [[package]]
 name = "zenoh-cfg-properties"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "zenoh-core",
  "zenoh-macros",
@@ -3268,7 +3268,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "uhlc",
  "zenoh-buffers",
@@ -3279,7 +3279,7 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "zenoh-core",
 ]
@@ -3287,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "zenoh-config"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "flume",
  "json5",
@@ -3305,7 +3305,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "anyhow",
  "async-std",
@@ -3316,7 +3316,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "aes 0.8.2",
  "hmac 0.12.1",
@@ -3329,7 +3329,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3349,7 +3349,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3366,7 +3366,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3389,7 +3389,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3404,7 +3404,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -3426,7 +3426,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3444,7 +3444,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3461,7 +3461,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3480,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3492,7 +3492,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "libloading",
  "log",
@@ -3505,7 +3505,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "hex",
  "rand 0.8.5",
@@ -3519,7 +3519,7 @@ dependencies = [
 [[package]]
 name = "zenoh-shm"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "bincode",
  "log",
@@ -3532,7 +3532,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "event-listener",
@@ -3547,7 +3547,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-executor",
  "async-global-executor",
@@ -3577,7 +3577,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3605,7 +3605,7 @@ dependencies = [
 [[package]]
 name = "zenoh_backend_traits"
 version = "0.7.0-rc"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#a2120eacafba46104a962fa32495250310578d55"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=master#d173f1e9580cdae6d3aa9b864e97b41463094f67"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,21 +33,17 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 async-std = "=1.12.0"
-async-trait = "0.1.57"
+async-trait = "0.1.60"
 base64 = "0.20.0"
 env_logger = "0.10.0"
 git-version = "0.3.5"
 humantime = "2.1.0"
-influxdb = { version = "0.5.2", default-features = false, features = [
-    "derive",
-    "use-serde",
-    "h1-client-rustls",
-] }
+influxdb = { version = "0.5.2", default-features = false, features = ["derive", "use-serde", "h1-client-rustls"] }
 lazy_static = "1.4.0"
 log = "0.4.17"
-serde = { version = "1.0.144", features = ["derive"] }
-serde_json = "1.0.85"
-uuid = { version = "1.1.2", features = ["v4"] }
+serde = { version = "1.0.152", features = ["derive"] }
+serde_json = "1.0.89"
+uuid = { version = "1.2.2", features = ["v4"] }
 zenoh = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master", features = [ "unstable" ] }
 zenoh_backend_traits = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master" }
 zenoh-collections = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 async-std = "=1.12.0"
 async-trait = "0.1.60"
-base64 = "0.20.0"
+base64 = "0.21.0"
 env_logger = "0.10.0"
 git-version = "0.3.5"
 humantime = "2.1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 
 use async_std::task;
 use async_trait::async_trait;
+use base64::{Engine, engine::general_purpose::STANDARD as b64_std_engine};
 use influxdb::{
     Client, ReadQuery as InfluxRQuery, Timestamp as InfluxTimestamp, WriteQuery as InfluxWQuery,
 };
@@ -407,7 +408,7 @@ impl Storage for InfluxDbStorage {
                 let (base64, strvalue) =
                     match String::from_utf8(sample.payload.contiguous().into_owned()) {
                         Ok(s) => (false, s),
-                        Err(err) => (true, base64::encode(err.into_bytes())),
+                        Err(err) => (true, b64_std_engine.encode(err.into_bytes())),
                     };
 
                 // Note: tags are stored as strings in InfluxDB, while fileds are typed.
@@ -551,7 +552,7 @@ impl Storage for InfluxDbStorage {
                                     };
                                     // get the payload
                                     let payload = if zpoint.base64 {
-                                        match base64::decode(zpoint.value) {
+                                        match b64_std_engine.decode(zpoint.value) {
                                             Ok(v) => ZBuf::from(v),
                                             Err(e) => {
                                                 warn!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 
 use async_std::task;
 use async_trait::async_trait;
-use base64::{Engine, engine::general_purpose::STANDARD as b64_std_engine};
+use base64::{engine::general_purpose::STANDARD as b64_std_engine, Engine};
 use influxdb::{
     Client, ReadQuery as InfluxRQuery, Timestamp as InfluxTimestamp, WriteQuery as InfluxWQuery,
 };


### PR DESCRIPTION
Related to [this](https://github.com/eclipse-zenoh/zenoh/pull/420), but here there is actually no need for a workspace since there is a single crate. Versions were matched with main repository.