### PR TITLE
Revert influxdb version bump.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ base64 = "0.21.0"
 env_logger = "0.10.0"
 git-version = "0.3.5"
 humantime = "2.1.0"
-influxdb = { version = "0.6.0", default-features = false, features = ["derive", "use-serde", "h1-client-rustls"] }
+influxdb = { version = "0.5.2", default-features = false, features = ["derive", "use-serde", "h1-client-rustls"] }
 lazy_static = "1.4.0"
 log = "0.4.17"
 serde = { version = "1.0.154", features = ["derive"] }


### PR DESCRIPTION
InfluxDB crate 0.6.0 is breaking the put, although get is still working.
We are proposing to revert it, until further investigation.