### PR TITLE
feat: adding dynamic_plugin feature to enable the declare_plugin macro

### DIFF
--- a/v1/Cargo.toml
+++ b/v1/Cargo.toml
@@ -17,6 +17,8 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 stats = ["zenoh/stats"]
+dynamic_plugin = []
+default = ["dynamic_plugin"]
 
 
 [dependencies]

--- a/v1/src/lib.rs
+++ b/v1/src/lib.rs
@@ -100,6 +100,8 @@ fn get_private_conf<'a>(
 }
 
 pub struct InfluxDbBackend {}
+
+#[cfg(feature = "dynamic_plugin")]
 zenoh_plugin_trait::declare_plugin!(InfluxDbBackend);
 
 impl Plugin for InfluxDbBackend {

--- a/v2/Cargo.toml
+++ b/v2/Cargo.toml
@@ -17,7 +17,8 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 stats = ["zenoh/stats"]
-
+dynamic_plugin = []
+default = ["dynamic_plugin"]
 
 [dependencies]
 async-std = { workspace = true }

--- a/v2/src/lib.rs
+++ b/v2/src/lib.rs
@@ -128,6 +128,8 @@ fn extract_credentials(config: Config) -> ZResult<Option<InfluxDbCredentials>> {
 }
 
 pub struct InfluxDbBackend {}
+
+#[cfg(feature = "dynamic_plugin")]
 zenoh_plugin_trait::declare_plugin!(InfluxDbBackend);
 
 impl Plugin for InfluxDbBackend {


### PR DESCRIPTION
Adding a `dynamic_plugin`  feature to feature-gate the `zenoh_plugin_trait::declare_plugin!` by default this feature is enabled.

Disabling it should allow static linking.