### PR TITLE
Use volume credentials when none are provided in storage config

### DIFF
--- a/v2/EXAMPLE_CONFIG.json5
+++ b/v2/EXAMPLE_CONFIG.json5
@@ -37,8 +37,8 @@
             // variants include `drop_series`, `drop_db`, `do_nothing`
             on_closure: "do_nothing",
             private: {
-              // Required 
               // InfluxDB credentials, with read/write privileges for the database
+              // If not provided, will use volume private fields instead
               // the org_id value should be the same as for admin
               org_id: "organization ID",
               // this is a token with either:

--- a/v2/src/lib.rs
+++ b/v2/src/lib.rs
@@ -158,7 +158,19 @@ fn extract_credentials(config: Config) -> ZResult<Option<InfluxDbCredentials>> {
             org_id: org_id.clone(),
             token: token.clone(),
         })),
-        _ => Ok(None),
+        (None, None) => Ok(None),
+        _ => {
+            tracing::error!(
+                "Couldn't get {} and {} from config",
+                PROP_BACKEND_ORG_ID,
+                PROP_TOKEN
+            );
+            bail!(
+                "Properties `{}` and `{}` must both exist",
+                PROP_BACKEND_ORG_ID,
+                PROP_TOKEN
+            );
+        }
     }
 }
 


### PR DESCRIPTION
Backend will use `org_id` and `token` configured in `volume.private` if none are provided in `storage.volume.private`.

Note: providing only one of `org_id` or `token` in storage config is an error case.