### PR TITLE
Fix Influxdb-v2 range construction

### DIFF
--- a/v2/src/lib.rs
+++ b/v2/src/lib.rs
@@ -952,7 +952,9 @@ fn timerange_from_parameters(p: &str) -> ZResult<Option<String>> {
                     result.push_str("start:");
                     write_timeexpr(&mut result, t, 1);
                 }
-                TimeBound::Unbounded => {}
+                TimeBound::Unbounded => {
+                    result.push_str("start:1970-01-01T00:00:00Z");
+                }
             }
             match stop {
                 TimeBound::Inclusive(t) => {


### PR DESCRIPTION
`start` field is required by influxdb2 API, but is omitted in our implementation when it is not provided in the request's `_time` parameter.
This PR sets the `start` field to the smallest possible value when not provided.