### PR TITLE
README: update zenohd instructions to load REST plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ You can setup storages either at zenoh router startup via a configuration file, 
 
 ### **Setup at runtime via `curl` commands on the admin space**
 
-  - Run the zenoh router, with write permissions to its admin space:
-    `zenohd --adminspace-permissions rw`
+  - Run the zenoh router, with write permissions to its admin space and with the REST plugin:  
+    `zenohd --adminspace-permissions=rw --rest-http-port=8000`
   - Add the "influxdb" volume (the "zenoh_backend_fs" library will be loaded), connected to InfluxDB service on http://localhost:8086:
     `curl -X PUT -H 'content-type:application/json' -d '{url:"http://localhost:8086"}' http://localhost:8000/@/router/local/config/plugins/storage_manager/volumes/influxdb`
   - Add the "demo" storage using the "influxdb" volume:

--- a/v1/README.md
+++ b/v1/README.md
@@ -125,8 +125,8 @@ You can setup storages either at zenoh router startup via a configuration file, 
 
 ### **Setup at runtime via `curl` commands on the admin space**
 
-  - Run the zenoh router, with write permissions to its admin space:  
-    `zenohd --adminspace-permissions rw`
+  - Run the zenoh router, with write permissions to its admin space and with the REST plugin:  
+    `zenohd --adminspace-permissions=rw --rest-http-port=8000`
   - Add the "influxdb" volume (the "zenoh_backend_fs" library will be loaded), connected to InfluxDB service on http://localhost:8086:
     `curl -X PUT -H 'content-type:application/json' -d '{url:"http://localhost:8086"}' http://localhost:8000/@/router/local/config/plugins/storage_manager/volumes/influxdb`
   - Add the "demo" storage using the "influxdb" volume:

--- a/v2/README.md
+++ b/v2/README.md
@@ -113,8 +113,8 @@ You can setup storages either at zenoh router startup via a configuration file, 
 
 ### **Setup at runtime via `curl` commands on the admin space**
 
-  - Run the zenoh router, with write permissions to its admin space:  
-    `zenohd --adminspace-permissions rw`
+  - Run the zenoh router, with write permissions to its admin space and with the REST plugin:  
+    `zenohd --adminspace-permissions=rw --rest-http-port=8000`
   - Add the "influxdb2" volume (the "zenoh_backend_fs" library will be loaded), connected to InfluxDB service on http://localhost:8086:
     `curl -X PUT -H 'content-type:application/json' -d '{url:"http://localhost:8086/api/v2"}' http://localhost:8000/@/router/local/config/plugins/storage_manager/volumes/influxdb2`
   - Add the "demo" storage using the "influxdb2" volume:


### PR DESCRIPTION
Following https://github.com/eclipse-zenoh/zenoh/pull/1593 `zenohd` no longer loads the REST plugin by default.
This PR updates the READMEs to add `--rest-http-port=8000` to `zenohd` startup instructions.