### PR TITLE
bug: Fixed payload written to influxdb 2

### DIFF
--- a/v2/src/lib.rs
+++ b/v2/src/lib.rs
@@ -558,7 +558,7 @@ impl Storage for InfluxDbStorage {
 
         let (base64, strvalue) = match payload.try_to_string() {
             Ok(s) => (false, s),
-            Err(err) => (true, b64_std_engine.encode(err.to_string()).into()),
+            Err(_) => (true, b64_std_engine.encode(payload.to_bytes()).into()),
         };
 
         // Note: tags are stored as strings in InfluxDB, while fileds are typed.


### PR DESCRIPTION
# What dose this pr do?
This pr fixes bug pointed in issue https://github.com/eclipse-zenoh/zenoh-backend-influxdb/issues/302

# How was this pr tested?
- Data was published from a ROS2 publisher using the ROS2DDS plugin, stored in the database, and later retrieved from InfluxDB 2 for deserialization.

Before update:
```
Message deserialization error
```

After update
```
Hello World
```